### PR TITLE
Bias fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,13 @@ pip3 install -r offpolicy_selection_eslb/requirements.txt
 ## Usage
 
 To run the benchmark on the UCI datasets considered in the paper, execute:
+```
+offpolicy_selection_eslb/demo/run.sh
+```
+or
 
 ```
-python3 demo/benchmark.py --dataset_type=uci_all --n_trials=10 --delta=0.01
+python3 -m offpolicy_selection_eslb.demo.benchmark --dataset_type=uci_all --n_trials=5 --delta=0.01
 ```
 
 This will run a full benchmark. You can replace `uci_all` in the above with

--- a/colabs/eslb_synthetic_example.ipynb
+++ b/colabs/eslb_synthetic_example.ipynb
@@ -1,433 +1,459 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "S4_XUChf7kag"
-      },
-      "source": [
-        "Implements ESLB value estimator for contextual bandit off-policy problem.\n",
-        "\n",
-        "All estimators are described in\n",
-        "\"Kuzborskij, I., Vernade, C., Gyorgy, A., \u0026 Szepesvári, C. (2021, March).\n",
-        "Confident off-policy evaluation and selection through self-normalized importance\n",
-        "weighting. In International Conference on Artificial Intelligence and Statistics\n",
-        "(pp. 640-648). PMLR.\".\n",
-        "In the following we occassionally refer to the statements in the paper\n",
-        "(e.g. Theorem 1, Proposition 1).\n",
-        "\n",
-        "class ESLB implements an Efron-Stein high probability bound for off-policy\n",
-        "evaluation (Theorem 1 and Algorithm 1)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "metadata": {
-        "executionInfo": {
-          "elapsed": 7,
-          "status": "ok",
-          "timestamp": 1635962607507,
-          "user": {
-            "displayName": "",
-            "photoUrl": "",
-            "userId": ""
-          },
-          "user_tz": -60
-        },
-        "id": "AWJ2V9Fy7gvP"
-      },
-      "outputs": [],
-      "source": [
-        "# Copyright 2021 DeepMind Technologies Limited.\n",
-        "#\n",
-        "#\n",
-        "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-        "# you may not use this file except in compliance with the License.\n",
-        "# You may obtain a copy of the License at\n",
-        "#\n",
-        "# https://www.apache.org/licenses/LICENSE-2.0\n",
-        "#\n",
-        "# Unless required by applicable law or agreed to in writing, software\n",
-        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-        "# See the License for the specific language governing permissions and\n",
-        "# limitations under the License."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 2,
-      "metadata": {
-        "executionInfo": {
-          "elapsed": 7,
-          "status": "ok",
-          "timestamp": 1635962611274,
-          "user": {
-            "displayName": "",
-            "photoUrl": "",
-            "userId": ""
-          },
-          "user_tz": -60
-        },
-        "id": "IfalmppW7nSg"
-      },
-      "outputs": [],
-      "source": [
-        "import logging\n",
-        "import math\n",
-        "import numpy as np"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "eGhEOqUQ7tv4"
-      },
-      "source": [
-        "# Tools"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 3,
-      "metadata": {
-        "executionInfo": {
-          "elapsed": 8,
-          "status": "ok",
-          "timestamp": 1635962612546,
-          "user": {
-            "displayName": "",
-            "photoUrl": "",
-            "userId": ""
-          },
-          "user_tz": -60
-        },
-        "id": "EORt_PYf7qmg"
-      },
-      "outputs": [],
-      "source": [
-        "def sample_from_simplices_m_times(p, m):\n",
-        "  \"\"\"Samples from each of n probability simplices for m times.\n",
-        "\n",
-        "  Args:\n",
-        "    p: n-times-K matrix where each row describes a probability simplex\n",
-        "    m: number of times to sample\n",
-        "\n",
-        "  Returns:\n",
-        "    n-times-m matrix of indices of simplex corners.\n",
-        "  \"\"\"\n",
-        "  axis = 1\n",
-        "  r = np.expand_dims(np.random.rand(p.shape[1 - axis], m), axis=axis)\n",
-        "  p_ = np.expand_dims(p.cumsum(axis=axis), axis=2)\n",
-        "  return (np.repeat(p_, m, axis=2) \u003e r).argmax(axis=1)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "cz0tGqIE7yAQ"
-      },
-      "source": [
-        "# Implementation of the ESLB estimator"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 4,
-      "metadata": {
-        "executionInfo": {
-          "elapsed": 114,
-          "status": "ok",
-          "timestamp": 1635962613969,
-          "user": {
-            "displayName": "",
-            "photoUrl": "",
-            "userId": ""
-          },
-          "user_tz": -60
-        },
-        "id": "1EQGSySA71di"
-      },
-      "outputs": [],
-      "source": [
-        "class ESLB():\n",
-        "  \"\"\"Implements a Semi-Empirical Efron-Stein bound for the SNIW (Self-normalized Importance Weighted estimator).\n",
-        "\n",
-        "  Attributes:\n",
-        "    delta: error probability in (0,1).\n",
-        "    n_iterations: number of Monte-Carlo simulation iterations for approximating\n",
-        "      a multiplicative bias and a variance proxy.\n",
-        "    n_batch_size: Monte-Carlo simulation batch size.\n",
-        "  \"\"\"\n",
-        "\n",
-        "  def __init__(self, delta, n_iterations, n_batch_size):\n",
-        "    \"\"\"Constructs an estimator.\n",
-        "\n",
-        "    The estimate holds with probability 1-delta.\n",
-        "\n",
-        "    Args:\n",
-        "      delta: delta: error probability in (0,1) for a confidence interval\n",
-        "      n_iterations: Monte-Carlo simulation iterations\n",
-        "      n_batch_size: Monte-Carlo simulation batch size\n",
-        "    \"\"\"\n",
-        "    self.delta = delta\n",
-        "    self.n_iterations = n_iterations\n",
-        "    self.n_batch_size = n_batch_size\n",
-        "\n",
-        "  def get_name(self):\n",
-        "    \"\"\"Returns a long name of an estimator.\"\"\"\n",
-        "    return \"Semi-Empirical Efron-Stein bound for the Self-normalized Estimator\"\n",
-        "\n",
-        "  def get_abbrev(self):\n",
-        "    \"\"\"Returns a short name of an estimator.\"\"\"\n",
-        "    return \"ESLB\"\n",
-        "\n",
-        "  def __call__(self, t_probs, b_probs, actions, rewards):\n",
-        "    \"\"\"Computes Efron-Stein lower bound of Theorem 1 as described in Algorithm 1.\n",
-        "\n",
-        "    Here n is a sample size, while K is a number actions.\n",
-        "\n",
-        "    Args:\n",
-        "      t_probs: n-times-K matrix, where $i$-th row corresponds to π_t(. | X_i)\n",
-        "      b_probs: n-times-K matrix, where $i$-th row corresponds to π_b(. | X_i)\n",
-        "      actions: n-sized vector of actions\n",
-        "      rewards: n-sized reward vector\n",
-        "\n",
-        "    Returns:\n",
-        "      A dictionary with 8 entries:\n",
-        "        lower_bound: corresponds to the actual lower bound;\n",
-        "        estimate: same as lower_bound (required by select_policy(...))\n",
-        "        est_value: an empirical value, concentration is a concentration term;\n",
-        "        mult_bias: a multiplicative bias;\n",
-        "        concentration_of_contexts: Hoeffding term, concentration of contexts;\n",
-        "        var_proxy: a variance proxy;\n",
-        "        expected_variance_proxy: its estimated expected counterpart.\n",
-        "    \"\"\"\n",
-        "    conf = math.log(2.0 / self.delta)\n",
-        "    n = len(actions)\n",
-        "    ix_1_n = np.arange(n)\n",
-        "\n",
-        "    # Importance weights\n",
-        "    weights = t_probs[ix_1_n, actions] / b_probs[ix_1_n, actions]\n",
-        "\n",
-        "    weights_cumsum = weights.cumsum()\n",
-        "    weights_cumsum = np.repeat(\n",
-        "        np.expand_dims(weights_cumsum, axis=1), self.n_batch_size, axis=1)\n",
-        "    weights_repeated = np.repeat(\n",
-        "        np.expand_dims(weights, axis=1), self.n_batch_size, axis=1)\n",
-        "\n",
-        "    weight_table = t_probs / b_probs\n",
-        "\n",
-        "    var_proxy_unsumed = np.zeros((n,))\n",
-        "    expected_var_proxy_unsumed = np.zeros((n,))\n",
-        "    expected_recip_weights = 0.0\n",
-        "\n",
-        "    logging.debug(\n",
-        "        \"ESLB:: Running Monte-Carlo estimation of the variance proxy and bias\")\n",
-        "    logging.debug(\"ESLB:: iterations = %d, batch size = %d\", self.n_iterations,\n",
-        "                  self.n_batch_size)\n",
-        "\n",
-        "    for i in range(self.n_iterations):\n",
-        "      actions_sampled = sample_from_simplices_m_times(b_probs,\n",
-        "                                                      self.n_batch_size)\n",
-        "      weights_sampled = weight_table[ix_1_n, actions_sampled.T].T\n",
-        "      weights_sampled_cumsum = weights_sampled[::-1, :].cumsum(axis=0)[::-1, :]\n",
-        "      # Hybrid sums: sums of empirical and sampled weights\n",
-        "      weights_hybrid_sums = np.copy(weights_cumsum)\n",
-        "      weights_hybrid_sums[:-1, :] += weights_sampled_cumsum[1:, :]\n",
-        "\n",
-        "      actions_sampled_for_u = sample_from_simplices_m_times(\n",
-        "          b_probs, self.n_batch_size)\n",
-        "      weights_sampled_for_u = weight_table[ix_1_n, actions_sampled_for_u.T].T\n",
-        "      actions_sampled_for_bias = sample_from_simplices_m_times(\n",
-        "          b_probs, self.n_batch_size)\n",
-        "      weights_sampled_for_bias = weight_table[ix_1_n,\n",
-        "                                              actions_sampled_for_bias.T].T\n",
-        "\n",
-        "      weights_hybrid_sums_replace_k = weights_hybrid_sums - weights_repeated + weights_sampled\n",
-        "      weights_tilde = weights_repeated / weights_hybrid_sums\n",
-        "      u_tilde = weights_sampled_for_u / weights_hybrid_sums_replace_k\n",
-        "      var_proxy_t = (weights_tilde + u_tilde)**2\n",
-        "\n",
-        "      expected_var_proxy_new_item = ((weights_sampled /\n",
-        "                                      weights_sampled.sum(axis=0))**2).mean(\n",
-        "                                          axis=1)\n",
-        "      var_proxy_new_item = var_proxy_t.mean(axis=1)\n",
-        "\n",
-        "      expected_var_proxy_unsumed += (expected_var_proxy_new_item -\n",
-        "                                     expected_var_proxy_unsumed) / (\n",
-        "                                         i + 1)\n",
-        "      var_proxy_unsumed += (var_proxy_new_item - var_proxy_unsumed) / (i + 1)\n",
-        "\n",
-        "      bias_t = (1.0 / weights_sampled_for_bias.sum(axis=0)).mean()\n",
-        "      expected_recip_weights += (bias_t - expected_recip_weights) / (i + 1)\n",
-        "\n",
-        "    var_proxy = var_proxy_unsumed.sum()\n",
-        "    expected_var_proxy = expected_var_proxy_unsumed.sum()\n",
-        "\n",
-        "    eff_sample_size = 1.0 / expected_recip_weights\n",
-        "\n",
-        "    mult_bias = min(1.0, eff_sample_size / n)\n",
-        "    concentration = math.sqrt(\n",
-        "        2.0 * (var_proxy + expected_var_proxy) *\n",
-        "        (conf + 0.5 * math.log(1 + var_proxy / expected_var_proxy)))\n",
-        "    concentration_of_contexts = math.sqrt(conf / (2 * n))\n",
-        "    est_value = weights.dot(rewards) / weights.sum()\n",
-        "    lower_bound = mult_bias * (est_value -\n",
-        "                               concentration) - concentration_of_contexts\n",
-        "\n",
-        "    return dict(\n",
-        "        estimate=max(0, lower_bound),\n",
-        "        lower_bound=max(0, lower_bound),\n",
-        "        est_value=est_value,\n",
-        "        concentration=concentration,\n",
-        "        mult_bias=mult_bias,\n",
-        "        concentration_of_contexts=concentration_of_contexts,\n",
-        "        var_proxy=var_proxy,\n",
-        "        expected_var_proxy=expected_var_proxy)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "0zbtpZue72Zn"
-      },
-      "source": [
-        "Minimal working example for using ``ESLB'' class, where the behavior and target policies are Softmax policies with the mass concentrated on one action (different for each policy)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 5,
-      "metadata": {
-        "executionInfo": {
-          "elapsed": 33221,
-          "status": "ok",
-          "timestamp": 1635962648377,
-          "user": {
-            "displayName": "",
-            "photoUrl": "",
-            "userId": ""
-          },
-          "user_tz": -60
-        },
-        "id": "NZR5tI-n75ho",
-        "outputId": "97e1c4ca-2374-475f-b4c8-9f80687a1619"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "------------------------------------------------------------------\n",
-            "behavior policy:\t (0.40, 0.15, 0.15, 0.15, 0.15)\n",
-            "target policy:\t\t (0.15, 0.40, 0.15, 0.15, 0.15)\n",
-            "sample size:\t\t 100\n",
-            "value(pi):\t\t 0.405\n",
-            "ESLB:\t\t\t 0.000\n",
-            "hat{value}(pi):\t\t 0.406\n",
-            "conc.:\t\t\t 0.784\n",
-            "mult. bias:\t\t 0.993\n",
-            "conc. of contexts:\t 0.136\n",
-            "------------------------------------------------------------------\n",
-            "behavior policy:\t (0.40, 0.15, 0.15, 0.15, 0.15)\n",
-            "target policy:\t\t (0.15, 0.40, 0.15, 0.15, 0.15)\n",
-            "sample size:\t\t 1000\n",
-            "value(pi):\t\t 0.405\n",
-            "ESLB:\t\t\t 0.122\n",
-            "hat{value}(pi):\t\t 0.410\n",
-            "conc.:\t\t\t 0.245\n",
-            "mult. bias:\t\t 0.999\n",
-            "conc. of contexts:\t 0.043\n",
-            "------------------------------------------------------------------\n",
-            "behavior policy:\t (0.40, 0.15, 0.15, 0.15, 0.15)\n",
-            "target policy:\t\t (0.15, 0.40, 0.15, 0.15, 0.15)\n",
-            "sample size:\t\t 10000\n",
-            "value(pi):\t\t 0.405\n",
-            "ESLB:\t\t\t 0.306\n",
-            "hat{value}(pi):\t\t 0.397\n",
-            "conc.:\t\t\t 0.077\n",
-            "mult. bias:\t\t 1.000\n",
-            "conc. of contexts:\t 0.014\n"
-          ]
-        }
-      ],
-      "source": [
-        "np.random.seed(1)\n",
-        "\n",
-        "temp = 1  # temperature of Softmax policy\n",
-        "K = 5  # number of actions\n",
-        "delta_ = 0.05  # error probability of the lower bound\n",
-        "\n",
-        "b_ix = 0  # mass on the 0-th action in the behavior policy\n",
-        "t_ix = 1  # mass on the 1-st action in the target policy\n",
-        "\n",
-        "# Definition of the behavior Softmax policy\n",
-        "b_pot = np.zeros(K)\n",
-        "b_pot[b_ix] = 1\n",
-        "b_policy = np.exp(b_pot / temp)\n",
-        "b_policy /= b_policy.sum()\n",
-        "\n",
-        "# Definition of the target Softmax policy\n",
-        "t_pot = np.zeros(K)\n",
-        "t_pot[t_ix] = 1\n",
-        "t_policy = np.exp(t_pot / temp)\n",
-        "t_policy /= t_policy.sum()\n",
-        "\n",
-        "t_value = t_policy[t_ix]  # Value of the target policy\n",
-        "\n",
-        "# Computation of the lower bound for increasing number of observations\n",
-        "for n_ in [100, 1000, 10000]:\n",
-        "  actions_ = np.random.choice(range(K), size=n_, p=b_policy)\n",
-        "  rewards_ = np.array(actions_ == t_ix, dtype=int)\n",
-        "  b_probs_ = np.repeat(np.expand_dims(b_policy, 0), n_, axis=0)\n",
-        "  t_probs_ = np.repeat(np.expand_dims(t_policy, 0), n_, axis=0)\n",
-        "\n",
-        "  estimator = ESLB(delta=delta_, n_iterations=10, n_batch_size=1000)\n",
-        "  results = estimator(\n",
-        "      t_probs=t_probs_, b_probs=b_probs_, actions=actions_, rewards=rewards_)\n",
-        "\n",
-        "  print(\"------------------------------------------------------------------\")\n",
-        "  print(\"behavior policy:\\t (%s)\" %\n",
-        "        \", \".join(map(lambda x: \"%.2f\" % x, b_policy)))\n",
-        "  print(\"target policy:\\t\\t (%s)\" %\n",
-        "        \", \".join(map(lambda x: \"%.2f\" % x, t_policy)))\n",
-        "  print(\"sample size:\\t\\t %d\" % n_)\n",
-        "  print(\"value(pi):\\t\\t %.3f\" % t_value)\n",
-        "  print(\"ESLB:\\t\\t\\t %.3f\" % results[\"lower_bound\"])\n",
-        "  print(\"hat{value}(pi):\\t\\t %.3f\" % results[\"est_value\"])\n",
-        "  print(\"conc.:\\t\\t\\t %.3f\" % results[\"concentration\"])\n",
-        "  print(\"mult. bias:\\t\\t %.3f\" % results[\"mult_bias\"])\n",
-        "  print(\"conc. of contexts:\\t %.3f\" % results[\"concentration_of_contexts\"])"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "5eouWbfi-HQ7"
-      },
-      "outputs": [],
-      "source": [
-        ""
-      ]
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "collapsed_sections": [],
-      "name": "eslb_synthetic_example.ipynb",
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "S4_XUChf7kag"
+   },
+   "source": [
+    "Implements ESLB value estimator for contextual bandit off-policy problem.\n",
+    "\n",
+    "All estimators are described in\n",
+    "\"Kuzborskij, I., Vernade, C., Gyorgy, A., & Szepesvári, C. (2021, March).\n",
+    "Confident off-policy evaluation and selection through self-normalized importance\n",
+    "weighting. In International Conference on Artificial Intelligence and Statistics\n",
+    "(pp. 640-648). PMLR.\".\n",
+    "In the following we occassionally refer to the statements in the paper\n",
+    "(e.g. Theorem 1, Proposition 1).\n",
+    "\n",
+    "class ESLB implements an Efron-Stein high probability bound for off-policy\n",
+    "evaluation (Theorem 1 and Algorithm 1)."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "executionInfo": {
+     "elapsed": 7,
+     "status": "ok",
+     "timestamp": 1635962607507,
+     "user": {
+      "displayName": "",
+      "photoUrl": "",
+      "userId": ""
+     },
+     "user_tz": -60
+    },
+    "id": "AWJ2V9Fy7gvP"
+   },
+   "outputs": [],
+   "source": [
+    "# Copyright 2021 DeepMind Technologies Limited.\n",
+    "#\n",
+    "#\n",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "# https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "executionInfo": {
+     "elapsed": 7,
+     "status": "ok",
+     "timestamp": 1635962611274,
+     "user": {
+      "displayName": "",
+      "photoUrl": "",
+      "userId": ""
+     },
+     "user_tz": -60
+    },
+    "id": "IfalmppW7nSg"
+   },
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "import math\n",
+    "import enum\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "eGhEOqUQ7tv4"
+   },
+   "source": [
+    "# Tools"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "executionInfo": {
+     "elapsed": 8,
+     "status": "ok",
+     "timestamp": 1635962612546,
+     "user": {
+      "displayName": "",
+      "photoUrl": "",
+      "userId": ""
+     },
+     "user_tz": -60
+    },
+    "id": "EORt_PYf7qmg"
+   },
+   "outputs": [],
+   "source": [
+    "def sample_from_simplices_m_times(p, m):\n",
+    "  \"\"\"Samples from each of n probability simplices for m times.\n",
+    "\n",
+    "  Args:\n",
+    "    p: n-times-K matrix where each row describes a probability simplex\n",
+    "    m: number of times to sample\n",
+    "\n",
+    "  Returns:\n",
+    "    n-times-m matrix of indices of simplex corners.\n",
+    "  \"\"\"\n",
+    "  axis = 1\n",
+    "  r = np.expand_dims(np.random.rand(p.shape[1 - axis], m), axis=axis)\n",
+    "  p_ = np.expand_dims(p.cumsum(axis=axis), axis=2)\n",
+    "  return (np.repeat(p_, m, axis=2) > r).argmax(axis=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "cz0tGqIE7yAQ"
+   },
+   "source": [
+    "# Implementation of the ESLB estimator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "executionInfo": {
+     "elapsed": 114,
+     "status": "ok",
+     "timestamp": 1635962613969,
+     "user": {
+      "displayName": "",
+      "photoUrl": "",
+      "userId": ""
+     },
+     "user_tz": -60
+    },
+    "id": "1EQGSySA71di"
+   },
+   "outputs": [],
+   "source": [
+    "class ESLBBiasType(enum.Enum):\n",
+    "  \"\"\"Bias control type of ESLB estimator.\n",
+    "\n",
+    "  ESLBBiasType.MultOneHot = Multiplicative bias (only for `one-hot' rewards).\n",
+    "  ESLBBiasType.Bernstein = Bernstein bias (for rewards in [0,1], looser than above).\n",
+    "  \"\"\"\n",
+    "  MultOneHot = \"MultOneHot\"\n",
+    "  Bernstein = \"Bernstein\"\n",
+    "\n",
+    "  def __str__(self):\n",
+    "    return str(self.value)\n",
+    "\n",
+    "class ESLB(object):\n",
+    "  \"\"\"Implements a Semi-Empirical Efron-Stein bound for the SNIW (Self-normalized Importance Weighted estimator).\n",
+    "\n",
+    "  Attributes:\n",
+    "    delta: Error probability in (0,1).\n",
+    "    n_iterations: Number of Monte-Carlo simulation iterations for approximating\n",
+    "      a multiplicative bias and a variance proxy.\n",
+    "    n_batch_size: Monte-Carlo simulation batch size.\n",
+    "    bias_type: type of bias control to use (see ESLBBiasType).\n",
+    "  \"\"\"\n",
+    "\n",
+    "  def __init__(\n",
+    "      self,\n",
+    "      delta: float,\n",
+    "      n_iterations: int,\n",
+    "      n_batch_size: int,\n",
+    "      bias_type: ESLBBiasType\n",
+    "  ):\n",
+    "    \"\"\"Constructs an estimator.\n",
+    "\n",
+    "    The estimate holds with probability 1-delta.\n",
+    "\n",
+    "    Args:\n",
+    "      delta: delta: Error probability in (0,1) for a confidence interval.\n",
+    "      n_iterations: Monte-Carlo simulation iterations.\n",
+    "      n_batch_size: Monte-Carlo simulation batch size.\n",
+    "      bias_type: type of bias control to use.\n",
+    "    \"\"\"\n",
+    "    self.delta = delta\n",
+    "    self.n_iterations = n_iterations\n",
+    "    self.n_batch_size = n_batch_size\n",
+    "    self.bias_type = bias_type\n",
+    "\n",
+    "  def get_name(self):\n",
+    "    \"\"\"Returns the long name of the estimator.\"\"\"\n",
+    "    return \"Semi-Empirical Efron-Stein bound for the Self-normalized Estimator\"\n",
+    "\n",
+    "  def get_abbrev(self):\n",
+    "    \"\"\"Returns the short name of the estimator.\"\"\"\n",
+    "    return \"ESLB\"\n",
+    "\n",
+    "  def __call__(\n",
+    "      self,\n",
+    "      t_probs: np.ndarray,\n",
+    "      b_probs: np.ndarray,\n",
+    "      actions: np.ndarray,\n",
+    "      rewards: np.ndarray,\n",
+    "  ):\n",
+    "    \"\"\"Computes Efron-Stein lower bound of Theorem 1 as described in Algorithm 1.\n",
+    "\n",
+    "    Here n is a sample size, while K is a number actions.\n",
+    "\n",
+    "    Args:\n",
+    "      t_probs: n-times-K matrix, where i-th row corresponds to π_t(. | X_i)\n",
+    "        (target probabilities under the target policy).\n",
+    "      b_probs: n-times-K matrix, where i-th row corresponds to π_b(. | X_i)\n",
+    "        (target probabilities under the behavior policy).\n",
+    "      actions: n-sized vector of actions.\n",
+    "      rewards: n-sized reward vector.\n",
+    "\n",
+    "    Returns:\n",
+    "      A dictionary with 8 entries:\n",
+    "        lower_bound: Corresponds to the actual lower bound.\n",
+    "        estimate: Same as lower_bound (required by select_policy(...)).\n",
+    "        est_value: Empirical value.\n",
+    "        mult_bias: Multiplicative bias.\n",
+    "        concentration_of_contexts: Hoeffding term, concentration of contexts.\n",
+    "        var_proxy: Variance proxy.\n",
+    "        expected_variance_proxy: Estimated expected counterpart.\n",
+    "    \"\"\"\n",
+    "    conf = math.log(2.0 / self.delta)\n",
+    "    n = len(actions)\n",
+    "    ix_1_n = np.arange(n)\n",
+    "\n",
+    "    # Importance weights\n",
+    "    weights = t_probs[ix_1_n, actions] / b_probs[ix_1_n, actions]\n",
+    "\n",
+    "    weights_cumsum = weights.cumsum()\n",
+    "    weights_cumsum = np.repeat(\n",
+    "        np.expand_dims(weights_cumsum, axis=1), self.n_batch_size, axis=1)\n",
+    "    weights_repeated = np.repeat(\n",
+    "        np.expand_dims(weights, axis=1), self.n_batch_size, axis=1)\n",
+    "\n",
+    "    weight_table = t_probs / b_probs\n",
+    "\n",
+    "    var_proxy_unsumed = np.zeros((n,))\n",
+    "    expected_var_proxy_unsumed = np.zeros((n,))\n",
+    "    loo_expected_recip_weights = 0.0\n",
+    "\n",
+    "    are_rewards_binary = ((rewards==0) | (rewards==1)).all()\n",
+    "    if self.bias_type == ESLBBiasType.MultOneHot and not are_rewards_binary:\n",
+    "      raise Exception(\"\"\"bias_type=ESLBBiasType.MultOneHot only supports one-hot rewards. \n",
+    "Consider using bias_type=ESLBBiasType.Bernstein\"\"\")\n",
+    "\n",
+    "    logging.debug(\n",
+    "        \"ESLB:: Running Monte-Carlo estimation of the variance proxy and bias\")\n",
+    "    logging.debug(\"ESLB:: iterations = %d, batch size = %d\", self.n_iterations,\n",
+    "                  self.n_batch_size)\n",
+    "\n",
+    "    for i in range(self.n_iterations):\n",
+    "      actions_sampled = sample_from_simplices_m_times(\n",
+    "          b_probs, self.n_batch_size)\n",
+    "      weights_sampled = weight_table[ix_1_n, actions_sampled.T].T\n",
+    "      weights_sampled_cumsum = weights_sampled[::-1, :].cumsum(axis=0)[::-1, :]\n",
+    "      # Hybrid sums: sums of empirical and sampled weights\n",
+    "      weights_hybrid_sums = np.copy(weights_cumsum)\n",
+    "      weights_hybrid_sums[:-1, :] += weights_sampled_cumsum[1:, :]\n",
+    "\n",
+    "      # Computing variance proxy\n",
+    "      weights_hybrid_sums_replace_k = weights_hybrid_sums - weights_repeated + weights_sampled\n",
+    "\n",
+    "      sn_weights = weights_repeated / weights_hybrid_sums\n",
+    "      sn_weights_prime = weights_sampled / weights_hybrid_sums_replace_k\n",
+    "\n",
+    "      var_proxy_t = (sn_weights + sn_weights_prime)**2\n",
+    "      var_proxy_new_item = var_proxy_t.mean(axis=1)\n",
+    "      var_proxy_unsumed += (var_proxy_new_item - var_proxy_unsumed) / (i + 1)\n",
+    "\n",
+    "      actions_sampled_for_expected_var = sample_from_simplices_m_times(\n",
+    "          b_probs, self.n_batch_size)\n",
+    "      weights_sampled_for_expected_var = weight_table[\n",
+    "          ix_1_n, actions_sampled_for_expected_var.T].T\n",
+    "\n",
+    "      expected_var_proxy_new_item = (\n",
+    "          (weights_sampled_for_expected_var /\n",
+    "           weights_sampled_for_expected_var.sum(axis=0))**2).mean(axis=1)\n",
+    "      expected_var_proxy_unsumed += (expected_var_proxy_new_item -\n",
+    "                                     expected_var_proxy_unsumed) / (i + 1)\n",
+    "\n",
+    "\n",
+    "      if self.bias_type == ESLBBiasType.MultOneHot:\n",
+    "        # Computing bias (loo = leave-one-out)\n",
+    "        # Rewards are `one-hot'\n",
+    "        actions_sampled_for_bias = sample_from_simplices_m_times(\n",
+    "          b_probs, self.n_batch_size)\n",
+    "        weights_sampled_for_bias = weight_table[ix_1_n,\n",
+    "                                                actions_sampled_for_bias.T].T\n",
+    "        loo_sum_weights = np.outer(\n",
+    "          np.ones((n,)),\n",
+    "          np.sum(weights_sampled_for_bias, axis=0)\n",
+    "        ) - weights_sampled_for_bias\n",
+    "        loo_expected_recip_weights += (1 / np.min(loo_sum_weights, axis=0)).mean()\n",
+    "\n",
+    "    var_proxy = var_proxy_unsumed.sum()\n",
+    "    expected_var_proxy = expected_var_proxy_unsumed.sum()\n",
+    "\n",
+    "    if self.bias_type == ESLBBiasType.MultOneHot:\n",
+    "      loo_expected_recip_weights /= self.n_iterations\n",
+    "      eff_sample_size = 1.0 / loo_expected_recip_weights\n",
+    "      mult_bias = min(1.0, eff_sample_size / n)\n",
+    "      add_bias = 0\n",
+    "    elif self.bias_type == ESLBBiasType.Bernstein:\n",
+    "      # Computing Bernstein bias control (based on lower tail Bernstein's inequality)\n",
+    "      expected_sum_weights_sq = (t_probs**2 / b_probs).sum()\n",
+    "      bias_x = math.log(n) / 2\n",
+    "      mult_bias = 1 - math.sqrt(2 * expected_sum_weights_sq * bias_x) / n\n",
+    "      mult_bias = max(0, mult_bias)\n",
+    "      add_bias = math.exp(-bias_x)\n",
+    "      \n",
+    "    concentration = math.sqrt(\n",
+    "        2.0 * (var_proxy + expected_var_proxy) *\n",
+    "        (conf + 0.5 * math.log(1 + var_proxy / expected_var_proxy)))\n",
+    "    concentration_of_contexts = math.sqrt(conf / (2 * n))\n",
+    "    est_value = weights.dot(rewards) / weights.sum()\n",
+    "    lower_bound = mult_bias * (est_value\n",
+    "                               - concentration\n",
+    "                               - add_bias) - concentration_of_contexts\n",
+    "\n",
+    "    return dict(\n",
+    "        estimate=max(0, lower_bound),\n",
+    "        lower_bound=max(0, lower_bound),\n",
+    "        est_value=est_value,\n",
+    "        concentration=concentration,\n",
+    "        mult_bias=mult_bias,\n",
+    "        concentration_of_contexts=concentration_of_contexts,\n",
+    "        var_proxy=var_proxy,\n",
+    "        expected_var_proxy=expected_var_proxy)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "0zbtpZue72Zn"
+   },
+   "source": [
+    "Minimal working example for using ``ESLB'' class, where the behavior and target policies are Softmax policies with the mass concentrated on one action (different for each policy)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "executionInfo": {
+     "elapsed": 33221,
+     "status": "ok",
+     "timestamp": 1635962648377,
+     "user": {
+      "displayName": "",
+      "photoUrl": "",
+      "userId": ""
+     },
+     "user_tz": -60
+    },
+    "id": "NZR5tI-n75ho",
+    "outputId": "97e1c4ca-2374-475f-b4c8-9f80687a1619"
+   },
+   "outputs": [],
+   "source": [
+    "np.random.seed(1)\n",
+    "\n",
+    "temp = 1  # temperature of Softmax policy\n",
+    "K = 5  # number of actions\n",
+    "delta_ = 0.05  # error probability of the lower bound\n",
+    "\n",
+    "b_ix = 0  # mass on the 0-th action in the behavior policy\n",
+    "t_ix = 1  # mass on the 1-st action in the target policy\n",
+    "\n",
+    "# Definition of the behavior Softmax policy\n",
+    "b_pot = np.zeros(K)\n",
+    "b_pot[b_ix] = 1\n",
+    "b_policy = np.exp(b_pot / temp)\n",
+    "b_policy /= b_policy.sum()\n",
+    "\n",
+    "# Definition of the target Softmax policy\n",
+    "t_pot = np.zeros(K)\n",
+    "t_pot[t_ix] = 1\n",
+    "t_policy = np.exp(t_pot / temp)\n",
+    "t_policy /= t_policy.sum()\n",
+    "\n",
+    "t_value = t_policy[t_ix]  # Value of the target policy\n",
+    "\n",
+    "# Computation of the lower bound for increasing number of observations\n",
+    "for n_ in [100, 1000, 10000]:\n",
+    "  actions_ = np.random.choice(range(K), size=n_, p=b_policy)\n",
+    "  rewards_ = np.array(actions_ == t_ix, dtype=int)\n",
+    "  b_probs_ = np.repeat(np.expand_dims(b_policy, 0), n_, axis=0)\n",
+    "  t_probs_ = np.repeat(np.expand_dims(t_policy, 0), n_, axis=0)\n",
+    "\n",
+    "  estimator = ESLB(delta=delta_, n_iterations=10, n_batch_size=1000, bias_type=ESLBBiasType.MultOneHot)\n",
+    "  results = estimator(\n",
+    "      t_probs=t_probs_, b_probs=b_probs_, actions=actions_, rewards=rewards_)\n",
+    "\n",
+    "  print(\"------------------------------------------------------------------\")\n",
+    "  print(\"behavior policy:\\t (%s)\" %\n",
+    "        \", \".join(map(lambda x: \"%.2f\" % x, b_policy)))\n",
+    "  print(\"target policy:\\t\\t (%s)\" %\n",
+    "        \", \".join(map(lambda x: \"%.2f\" % x, t_policy)))\n",
+    "  print(\"sample size:\\t\\t %d\" % n_)\n",
+    "  print(\"value(pi):\\t\\t %.3f\" % t_value)\n",
+    "  print(\"ESLB:\\t\\t\\t %.3f\" % results[\"lower_bound\"])\n",
+    "  print(\"hat{value}(pi):\\t\\t %.3f\" % results[\"est_value\"])\n",
+    "  print(\"conc.:\\t\\t\\t %.3f\" % results[\"concentration\"])\n",
+    "  print(\"mult. bias:\\t\\t %.3f\" % results[\"mult_bias\"])\n",
+    "  print(\"conc. of contexts:\\t %.3f\" % results[\"concentration_of_contexts\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "5eouWbfi-HQ7"
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "eslb_synthetic_example.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/data.py
+++ b/data.py
@@ -58,7 +58,7 @@ def get_reward(
     actions: np.ndarray,
     labels: np.ndarray,
     reward_noise_p: float = 0.1,
-    low_rew: float = 0.1,
+    low_rew: float = 0.0,
     high_rew: float = 1.,
 ):
   """Returns rewards and corrupted labels for matching actions.

--- a/demo/run.sh
+++ b/demo/run.sh
@@ -20,9 +20,8 @@ set -e
 python3 -m venv /tmp/eslb_venv
 source /tmp/eslb_venv/bin/activate
 pip3 install --upgrade pip setuptools wheel
-pip3 install -r ../requirements.txt
+pip3 install -r offpolicy_selection_eslb/requirements.txt
 
 # Runs an off-policy benchmark on UCI datasets with OpenML IDs 181, 30, 28, 182, 300, 32, 6, 184,
-# for 10 trials and confidence bound failure probability δ=0.01
-# ERROR python3 -m offpolicy_selection_eslb.demo.benchmark --dataset_type=uci_all --n_trials=10 --delta=0.01
-python3 benchmark.py --dataset_type=uci_all --n_trials=10 --delta=0.01
+# for 5 trials and confidence bound failure probability δ=0.01
+python3 -m offpolicy_selection_eslb.demo.benchmark --dataset_type=uci_all --n_trials=5 --delta=0.01


### PR DESCRIPTION
This fixes two issues:

- Pathing issue that appears during the import, which appears in demo/run.sh and README.md.
- Bias term control in the estimator ESLB contained a bug in the proof; The fix introduces two alternatives: when rewards are "one-hot" (as in the benchmark), the control is essentially the same. Otherwise there's a flag to use a bias control by lower tail Bernstein's inequality, which requires rewards to be in [0,1].